### PR TITLE
Enhancement towards nlme::lme and mgcv::gamm with correlation structure

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,11 +2,11 @@ Package: cAIC4
 Type: Package
 Title: Conditional Akaike Information Criterion for 'lme4'
 Version: 0.9
-Date: 2019-04-17
+Date: 2019-06-19
 Author: Benjamin Saefken, David Ruegamer and Philipp Baumann, with contributions from Sonja
     Greven and Thomas Kneib
 Maintainer: David Ruegamer <david.ruegamer@gmail.com>
-Depends: lme4(>= 1.1-6), methods, Matrix, stats4, nlme, RLRsim
+Depends: lme4(>= 1.1-6), methods, Matrix, stats4, nlme, RLRsim, mvtnorm
 Suggests: gamm4, mgcv
 Description: Provides functions for the estimation of the conditional Akaike
     information in generalized mixed-effect models fitted with (g)lmer() 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: cAIC4
 Type: Package
-Title: Conditional Akaike Information Criterion for 'lme4'
+Title: Conditional Akaike Information Criterion for 'lme4' and 'nlme'
 Version: 0.9
 Date: 2019-06-19
 Author: Benjamin Saefken, David Ruegamer and Philipp Baumann, with contributions from Sonja

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,16 +1,16 @@
 Package: cAIC4
 Type: Package
 Title: Conditional Akaike Information Criterion for 'lme4'
-Version: 0.8
+Version: 0.9
 Date: 2019-04-17
 Author: Benjamin Saefken, David Ruegamer and Philipp Baumann, with contributions from Sonja
     Greven and Thomas Kneib
 Maintainer: David Ruegamer <david.ruegamer@gmail.com>
-Depends: lme4(>= 1.1-6), methods, Matrix, stats4
+Depends: lme4(>= 1.1-6), methods, Matrix, stats4, nlme
 Suggests: gamm4, mgcv
 Description: Provides functions for the estimation of the conditional Akaike
     information in generalized mixed-effect models fitted with (g)lmer() 
-    from 'lme4'.
+    from 'lme4', lme from 'nlme' and gamm from 'mgcv'.
 License: GPL (>= 2)
 Packaged: 2019-02-01 22:44:08 UTC; david
 NeedsCompilation: no

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,7 +6,7 @@ Date: 2019-04-17
 Author: Benjamin Saefken, David Ruegamer and Philipp Baumann, with contributions from Sonja
     Greven and Thomas Kneib
 Maintainer: David Ruegamer <david.ruegamer@gmail.com>
-Depends: lme4(>= 1.1-6), methods, Matrix, stats4, nlme
+Depends: lme4(>= 1.1-6), methods, Matrix, stats4, nlme, RLRsim
 Suggests: gamm4, mgcv
 Description: Provides functions for the estimation of the conditional Akaike
     information in generalized mixed-effect models fitted with (g)lmer() 

--- a/R/cAIC.R
+++ b/R/cAIC.R
@@ -184,9 +184,13 @@ function(object, method = NULL, B = NULL, sigma.penalty = 1, analytic = TRUE) {
     attr(object$lme, "smooth_names") <- get_names(object) # old names
     attr(object$lme, "is_gamm") <- TRUE # add indicator for mgcv::gamm
     attr(object$lme, "gam_form") <- formula(object$gam) # for refit
-    # order columns in $data as in gamm4 and get ride of $gam
     object <- object$lme
-    attr(object,"ordered_smooth") <- sort_sterms(object) # new names
+    attr(object, "ordered_smooth") <- sort_sterms(object) # names as in gamm4
+  }
+
+  if (any(class(object) %in% "lme")) {
+    sigma.penalty <- count_par(object)
+    if (is.null(attr(object, "is_gamm"))) attr(object, "is_gamm") <- FALSE
   }
   
   ### START: calculation for GLMs and LMs
@@ -239,11 +243,6 @@ function(object, method = NULL, B = NULL, sigma.penalty = 1, analytic = TRUE) {
             Therefore the conditional parametric bootstrap is returned")
     method <- "conditionalBootstrap"
   }
-  
-  if (class(object) == "lme") {
-    sigma.penalty <- count_par(object)
-    attr(object, "is_gamm") <- FALSE
-  } 
   
   dfList   <- bcMer(object , 
                     method = method, 

--- a/R/cAIC.R
+++ b/R/cAIC.R
@@ -240,7 +240,10 @@ function(object, method = NULL, B = NULL, sigma.penalty = 1, analytic = TRUE) {
     method <- "conditionalBootstrap"
   }
   
-  if (class(object) == "lme") sigma.penalty <- count_par(object)
+  if (class(object) == "lme") {
+    sigma.penalty <- count_par(object)
+    attr(object, "is_gamm") <- FALSE
+  } 
   
   dfList   <- bcMer(object , 
                     method = method, 

--- a/R/cAIC.R
+++ b/R/cAIC.R
@@ -180,6 +180,14 @@ function(object, method = NULL, B = NULL, sigma.penalty = 1, analytic = TRUE) {
     object@optinfo$gamm4 <- TRUE    # add indicator for gamm4
   }
   
+  if (any(class(object) %in% "gamm")) {
+    attr(object$lme, "smooth_names") <- get_names(object) # old names
+    attr(object$lme, "is_gamm") <- TRUE # add indicator for mgcv::gamm
+    attr(object$lme, "gam_form") <- formula(object$gam) # for refit
+    # order columns in $data as in gamm4 and get ride of $gam
+    object <- object$lme
+    attr(object,"ordered_smooth") <- sort_sterms(object) # new names
+  }
   
   ### START: calculation for GLMs and LMs
   if (any(class(object) %in% c("glm","lm"))) {
@@ -231,6 +239,8 @@ function(object, method = NULL, B = NULL, sigma.penalty = 1, analytic = TRUE) {
             Therefore the conditional parametric bootstrap is returned")
     method <- "conditionalBootstrap"
   }
+  
+  if (class(object) == "lme") sigma.penalty <- count_par(object)
   
   dfList   <- bcMer(object , 
                     method = method, 

--- a/R/deleteZeroComponents.R
+++ b/R/deleteZeroComponents.R
@@ -49,81 +49,78 @@ deleteZeroComponents <- function(m) UseMethod("deleteZeroComponents")
 #' @rdname deleteZeroComponents
 #' @method deleteZeroComponents lme
 #' @S3method deleteZeroComponents lme
-deleteZeroComponents.lme <- 
-function(m) {
-  
-  theta <- get_theta(m)
-  thetazero <- which(theta == 0)
-  if (is.null(names(theta))){
-    true_re <- rep(T,length(theta))
-  } else {
-    true_re <- names(theta) == ""
-  } 
-  
-  if (length(thetazero) == 0) {
-    return(m)
-  }
-  
-  varBlockMatrices <- get_ST(m)
-  
-  re_name <- m$modelStruct$reStruct[1]
-  cnms <- attr(m$modelStruct$reStruct[[1]],"Dimnames")[1]
-  cnms <- cor_re(m,cnms)
-  
-  smooth_names <- attr(m,"smooth_names")
-  cnms <- c(cnms,smooth_names)
-  
-  for (i in 1:length(varBlockMatrices)) {
-    cnms[[i]] <- cnms[[i]][which(diag(varBlockMatrices[[i]]) != 0)]
-  }
-  
-  # modify random argument for refit
-  no_re <- sum(true_re)
-  left_bar <- deparse(attr(re_name[[1]],"formula")[[2]])
-  right_bar <- names(re_name)
-  is_indpt <- "pdDiag" %in% class(re_name[[1]])
-  r_effect <- formula(re_name)
-  
-  if (no_re == 3) {
-    if (theta[2] == 0) {
-      r_effect <- list()
-      r_effect[[right_bar]] <- pdDiag(as.formula(paste("~",left_bar)))
+deleteZeroComponents.lme <-
+  function(m) {
+    theta <- get_theta(m)
+    thetazero <- which(theta == 0)
+    if (is.null(names(theta))) {
+      true_re <- rep(T, length(theta))
+    } else {
+      true_re <- names(theta) == ""
     }
-    if (theta[1] == 0 & theta[2] == 0) {
-      r_effect <- list()
-      r_effect[[right_bar]] <- as.formula(paste("~ -1 + ",left_bar,"|",right_bar))
-    }
-    if (theta[2] == 0 & theta[3] == 0) {
-      r_effect <- list()
-      r_effect[[right_bar]] <- as.formula(paste("~ 1","|",right_bar))
-    } 
-  }
-  
-  if (is_indpt) {
-    
-    if (theta[1] == 0) {
-      r_effect <- list()
-      r_effect[[right_bar]] <- as.formula(paste("~ -1 + ",left_bar,"|",right_bar))
-    }
-    if (theta[2] == 0) {
-      r_effect <- list()
-      r_effect[[right_bar]] <- as.formula(paste("~ 1","|",right_bar))
-    } 
-    
-  }
-  
-  if (no_re == 1 & theta[1] == 0) cat("No random effect variance.")
-  
-  if (!attr(m,"is_gamm")){
-    new_lme <- update(m, formula(m), random = r_effect, evaluate = TRUE)
-    return(del_zero_comp(new_lme))
-  }
-  
-  g_m <- gamm(attr(m,"gam_form"),random = r_effect,data = m$data)
-  return(del_zero_comp(g_m))
-  
-}
 
+    if (length(thetazero) == 0) {
+      return(m)
+    }
+
+    varBlockMatrices <- get_ST(m)
+
+    re_name <- m$modelStruct$reStruct[1]
+    cnms <- attr(m$modelStruct$reStruct[[1]], "Dimnames")[1]
+    cnms <- cor_re(m, cnms)
+
+    smooth_names <- attr(m, "smooth_names")
+    cnms <- c(cnms, smooth_names)
+
+    for (i in 1:length(varBlockMatrices)) {
+      cnms[[i]] <- cnms[[i]][which(diag(varBlockMatrices[[i]]) != 0)]
+    }
+
+    # modify random argument for refit
+    no_re <- sum(true_re)
+    left_bar <- deparse(attr(re_name[[1]], "formula")[[2]])
+    right_bar <- names(re_name)
+    is_indpt <- "pdDiag" %in% class(re_name[[1]])
+    r_effect <- formula(re_name)
+
+    if (no_re == 3) {
+      if (theta[2] == 0) {
+        r_effect <- list()
+        r_effect[[right_bar]] <- pdDiag(as.formula(paste("~", left_bar)))
+      }
+      if (theta[1] == 0 & theta[2] == 0) {
+        r_effect <- list()
+        r_effect[[right_bar]] <- as.formula(paste("~ -1 + ", left_bar, "|", 
+                                                  right_bar))
+      }
+      if (theta[2] == 0 & theta[3] == 0) {
+        r_effect <- list()
+        r_effect[[right_bar]] <- as.formula(paste("~ 1", "|", right_bar))
+      }
+    }
+
+    if (is_indpt) {
+      if (theta[1] == 0) {
+        r_effect <- list()
+        r_effect[[right_bar]] <- as.formula(paste("~ -1 + ", left_bar, "|", 
+                                                  right_bar))
+      }
+      if (theta[2] == 0) {
+        r_effect <- list()
+        r_effect[[right_bar]] <- as.formula(paste("~ 1", "|", right_bar))
+      }
+    }
+
+    if (no_re == 1 & theta[1] == 0) cat("No random effect variance.")
+
+    if (!attr(m, "is_gamm")) {
+      new_lme <- update(m, formula(m), random = r_effect, evaluate = TRUE)
+      return(del_zero_comp(new_lme))
+    }
+
+    g_m <- gamm(attr(m, "gam_form"), random = r_effect, data = m$data)
+    return(del_zero_comp(g_m))
+  }
 #' @return \code{NULL}
 #'
 #' @rdname deleteZeroComponents

--- a/R/deleteZeroComponents.R
+++ b/R/deleteZeroComponents.R
@@ -52,8 +52,75 @@ deleteZeroComponents <- function(m) UseMethod("deleteZeroComponents")
 deleteZeroComponents.lme <- 
 function(m) {
   
-  ### Philipp's code
-  stop("Not implemented yet.")
+  theta <- get_theta(m)
+  thetazero <- which(theta == 0)
+  if (is.null(names(theta))){
+    true_re <- rep(T,length(theta))
+  } else {
+    true_re <- names(theta) == ""
+  } 
+  
+  if (length(thetazero) == 0) {
+    return(m)
+  }
+  
+  varBlockMatrices <- get_ST(m)
+  
+  re_name <- m$modelStruct$reStruct[1]
+  cnms <- attr(m$modelStruct$reStruct[[1]],"Dimnames")[1]
+  cnms <- cor_re(m,cnms)
+  
+  smooth_names <- attr(m,"smooth_names")
+  cnms <- c(cnms,smooth_names)
+  
+  for (i in 1:length(varBlockMatrices)) {
+    cnms[[i]] <- cnms[[i]][which(diag(varBlockMatrices[[i]]) != 0)]
+  }
+  
+  # modify random argument for refit
+  no_re <- sum(true_re)
+  left_bar <- deparse(attr(re_name[[1]],"formula")[[2]])
+  right_bar <- names(re_name)
+  is_indpt <- "pdDiag" %in% class(re_name[[1]])
+  r_effect <- formula(re_name)
+  
+  if (no_re == 3) {
+    if (theta[2] == 0) {
+      r_effect <- list()
+      r_effect[[right_bar]] <- pdDiag(as.formula(paste("~",left_bar)))
+    }
+    if (theta[1] == 0 & theta[2] == 0) {
+      r_effect <- list()
+      r_effect[[right_bar]] <- as.formula(paste("~ -1 + ",left_bar,"|",right_bar))
+    }
+    if (theta[2] == 0 & theta[3] == 0) {
+      r_effect <- list()
+      r_effect[[right_bar]] <- as.formula(paste("~ 1","|",right_bar))
+    } 
+  }
+  
+  if (is_indpt) {
+    
+    if (theta[1] == 0) {
+      r_effect <- list()
+      r_effect[[right_bar]] <- as.formula(paste("~ -1 + ",left_bar,"|",right_bar))
+    }
+    if (theta[2] == 0) {
+      r_effect <- list()
+      r_effect[[right_bar]] <- as.formula(paste("~ 1","|",right_bar))
+    } 
+    
+  }
+  
+  if (no_re == 1 & theta[1] == 0) cat("No random effect variance.")
+  
+  if (!attr(m,"is_gamm")){
+    new_lme <- update(m, formula(m), random = r_effect, evaluate = TRUE)
+    return(del_zero_comp(new_lme))
+  }
+  
+  g_m <- gamm(attr(m,"gam_form"),random = r_effect,data = m$data)
+  return(del_zero_comp(g_m))
   
 }
 

--- a/R/getModelComponents.R
+++ b/R/getModelComponents.R
@@ -61,7 +61,7 @@ getModelComponents.lme <-
       model$B <- matrix(0, length(theta), length(theta))
     } else {
       stop("Numerical Hessian not calculated in nlme::lme objects!")
-      model$B <- m@optinfo$derivs$Hessian
+      # model$B <- m@optinfo$derivs$Hessian
     }
     model$C <- matrix(0, length(theta), n)
     model$y <- y
@@ -101,8 +101,8 @@ function(m, analytic) {
   w             <- weights(m)
   if(any(w!=1)){
     
-    model$R <- diag(w)
-    Rinv <- diag(1/w)
+    model$R <- diag(1/w)
+    Rinv <- diag(w)
     D0inv <- solve(tcrossprod(Lambda))
     V0inv <- Rinv - crossprod(Rinv,Z) %*% solve(D0inv + t(Z)%*%Rinv%*%Z) %*% crossprod(Z,Rinv)
     

--- a/R/getModelComponents.R
+++ b/R/getModelComponents.R
@@ -4,7 +4,7 @@ getModelComponents.lme <-
   function(m, analytic = TRUE) {
     model <- list()
     model$df <- NULL
-    X <- m$data$X
+    X <- model.matrix(formula(m),m$data)
     n <- nrow(X)
     Z <- as.matrix(get_Z(m))
     theta <- get_theta(m)
@@ -12,17 +12,11 @@ getModelComponents.lme <-
     Lambda <- t(Lambdat)
     model$Wlist <- list()
     model$eWelist <- list()
-    L <- get_L(m)
-    stop("Fix me!")
-    # w <- weights(m)
+    # L <- get_L(m)
+
     sig2 <- sigma(m)^2
-    # if (length(w) == 0){
-    #   R <- diag(n)
-    # } else {
-    #   R <- diag(w)
-    # }
-    R <- get_R(m) / sig2 # definition according to ...
-    w <- sig2 / diag(get_R(m))
+    R <- get_R(m) / sig2 # definition according to derivation of bc with weights
+    # w <- sig2 / diag(get_R(m))
     Rinv <- solve(R)
     model$R <- R
     Zt <- t(Z)
@@ -32,7 +26,7 @@ getModelComponents.lme <-
 
     RX <- get_RX(m)
     A <- V0inv - crossprod(crossprod(X %*% solve(RX), V0inv))
-    y <- m$data$y
+    y <- as.vector(getResponse(m))
     e <- residuals(m)
 
     ## prepare list of derivative matrices W_j

--- a/R/getModelComponents.R
+++ b/R/getModelComponents.R
@@ -9,6 +9,7 @@ getModelComponents.lme <-
     Z <- as.matrix(get_Z(m))
     theta <- get_theta(m)
     Lambdat <- get_LambdaT(m)$LambdaT
+    D <- get_LambdaT(m)$D
     Lambda <- t(Lambdat)
     model$Wlist <- list()
     model$eWelist <- list()
@@ -20,9 +21,8 @@ getModelComponents.lme <-
     Rinv <- solve(R)
     model$R <- R
     Zt <- t(Z)
-    Dinv <- solve(get_LambdaT(m)$D)
-    V0inv <- Rinv - Rinv %*% Z %*% solve(Dinv + Zt %*% Rinv %*% Z) %*% Zt %*% 
-      Rinv
+    #Dinv <- solve(get_LambdaT(m)$D)
+    V0inv <- solve(Matrix(Z %*% D %*% Zt + get_R(m))/sig2)
 
     RX <- get_RX(m)
     A <- V0inv - crossprod(crossprod(X %*% solve(RX), V0inv))

--- a/R/getModelComponents.R
+++ b/R/getModelComponents.R
@@ -8,7 +8,7 @@ getModelComponents.lme <-
     n <- nrow(X)
     Z <- as.matrix(get_Z(m))
     theta <- get_theta(m)
-    Lambdat <- get_LambdaT(m)
+    Lambdat <- get_LambdaT(m)$LambdaT
     Lambda <- t(Lambdat)
     model$Wlist <- list()
     model$eWelist <- list()
@@ -20,7 +20,7 @@ getModelComponents.lme <-
     Rinv <- solve(R)
     model$R <- R
     Zt <- t(Z)
-    Dinv <- solve(sig2 * Lambda %*% Lambdat)
+    Dinv <- solve(get_LambdaT(m)$D)
     V0inv <- Rinv - Rinv %*% Z %*% solve(Dinv + Zt %*% Rinv %*% Z) %*% Zt %*% 
       Rinv
 

--- a/R/getModelComponents.R
+++ b/R/getModelComponents.R
@@ -14,14 +14,16 @@ function(m, analytic = TRUE) {
   model$Wlist <- list()
   model$eWelist <- list()
   L <- get_L(m)
-  
-  w <- weights(m)
+  stop("Fix me!")
+  # w <- weights(m)
   sig2 <- sigma(m)^2
-  if (length(w) == 0){
-    R <- diag(n)
-  } else {
-    R <- diag(w)
-  }
+  # if (length(w) == 0){
+  #   R <- diag(n)
+  # } else {
+  #   R <- diag(w)
+  # }
+  R <- get_R(m)/sig2 # definition according to ...
+  w <- sig2/diag(get_R(m))
   Rinv <- solve(R)
   model$R <- R
   Zt <- t(Z)

--- a/R/getModelComponents.R
+++ b/R/getModelComponents.R
@@ -1,83 +1,82 @@
 getModelComponents <- function(m, analytic) UseMethod("getModelComponents")
 
-getModelComponents.lme <- 
-function(m, analytic = TRUE) {
-  
-  model <- list()
-  model$df <- NULL
-  X <- m$data$X
-  n <- nrow(X)
-  Z <- as.matrix(get_Z(m))
-  theta <- get_theta(m)
-  Lambdat <- get_LambdaT(m)
-  Lambda <- t(Lambdat)
-  model$Wlist <- list()
-  model$eWelist <- list()
-  L <- get_L(m)
-  stop("Fix me!")
-  # w <- weights(m)
-  sig2 <- sigma(m)^2
-  # if (length(w) == 0){
-  #   R <- diag(n)
-  # } else {
-  #   R <- diag(w)
-  # }
-  R <- get_R(m)/sig2 # definition according to ...
-  w <- sig2/diag(get_R(m))
-  Rinv <- solve(R)
-  model$R <- R
-  Zt <- t(Z)
-  Dinv <- solve(sig2*Lambda%*%Lambdat)
-  V0inv <- Rinv - Rinv%*% Z %*% solve(Dinv + Zt%*%Rinv%*%Z) %*% Zt %*% Rinv
-  
-  RX <- get_RX(m)
-  A <- V0inv - crossprod(crossprod(X %*% solve(RX), V0inv))
-  y <- m$data$y
-  e <- residuals(m)
-  
-  ## prepare list of derivative matrices W_j
-  ind <- get_Lind(m)
-  len <- rep(0,length(Lambda@x))
-  
-  for (s in 1:length(theta)) {
-    # model$Wlist <- lapply(theta, function(s){
-    LambdaS <- Lambda
-    LambdaSt <- Lambdat
-    LambdaS@x <- LambdaSt@x <- len
-    LambdaS@x[which(ind == s)] <- LambdaSt@x[which(ind == s)] <- 1
-    diagonal <- diag(LambdaS)
-    diag(LambdaS) <- diag(LambdaSt) <- 0
-    Ds <- LambdaS + LambdaSt
-    diag(Ds) <- diagonal
-    model$Wlist[[s]] <- tcrossprod(Z %*% Ds, Z)
-    model$eWelist[[s]] <- as.numeric(e %*% model$Wlist[[s]] %*% e)
-    # model$Wlist[[s]]  <- model$Wlist[[s]]/norm(model$Wlist[[s]], type = "F")
+getModelComponents.lme <-
+  function(m, analytic = TRUE) {
+    model <- list()
+    model$df <- NULL
+    X <- m$data$X
+    n <- nrow(X)
+    Z <- as.matrix(get_Z(m))
+    theta <- get_theta(m)
+    Lambdat <- get_LambdaT(m)
+    Lambda <- t(Lambdat)
+    model$Wlist <- list()
+    model$eWelist <- list()
+    L <- get_L(m)
+    stop("Fix me!")
+    # w <- weights(m)
+    sig2 <- sigma(m)^2
+    # if (length(w) == 0){
+    #   R <- diag(n)
+    # } else {
+    #   R <- diag(w)
+    # }
+    R <- get_R(m) / sig2 # definition according to ...
+    w <- sig2 / diag(get_R(m))
+    Rinv <- solve(R)
+    model$R <- R
+    Zt <- t(Z)
+    Dinv <- solve(sig2 * Lambda %*% Lambdat)
+    V0inv <- Rinv - Rinv %*% Z %*% solve(Dinv + Zt %*% Rinv %*% Z) %*% Zt %*% 
+      Rinv
+
+    RX <- get_RX(m)
+    A <- V0inv - crossprod(crossprod(X %*% solve(RX), V0inv))
+    y <- m$data$y
+    e <- residuals(m)
+
+    ## prepare list of derivative matrices W_j
+    ind <- get_Lind(m)
+    len <- rep(0, length(Lambda@x))
+
+    for (s in 1:length(theta)) {
+      # model$Wlist <- lapply(theta, function(s){
+      LambdaS <- Lambda
+      LambdaSt <- Lambdat
+      LambdaS@x <- LambdaSt@x <- len
+      LambdaS@x[which(ind == s)] <- LambdaSt@x[which(ind == s)] <- 1
+      diagonal <- diag(LambdaS)
+      diag(LambdaS) <- diag(LambdaSt) <- 0
+      Ds <- LambdaS + LambdaSt
+      diag(Ds) <- diagonal
+      model$Wlist[[s]] <- tcrossprod(Z %*% Ds, Z)
+      model$eWelist[[s]] <- as.numeric(e %*% model$Wlist[[s]] %*% e)
+      # model$Wlist[[s]]  <- model$Wlist[[s]]/norm(model$Wlist[[s]], type = "F")
+    }
+
+    ## Write everything into a return list
+    model$X <- X
+    model$n <- n
+    model$theta <- theta
+    model$Z <- Z
+    model$Lambda <- Lambda
+    model$Lambdat <- Lambdat
+    model$V0inv <- V0inv
+    model$A <- A
+    if (analytic) {
+      model$B <- matrix(0, length(theta), length(theta))
+    } else {
+      stop("Numerical Hessian not calculated in nlme::lme objects!")
+      model$B <- m@optinfo$derivs$Hessian
+    }
+    model$C <- matrix(0, length(theta), n)
+    model$y <- y
+    model$e <- e
+    model$tye <- as.numeric(crossprod(y, e))
+    model$isREML <- m$method == "REML"
+
+    return(model)
   }
-  
-  ## Write everything into a return list
-  model$X <- X
-  model$n <- n
-  model$theta <- theta
-  model$Z <- Z
-  model$Lambda <- Lambda
-  model$Lambdat <- Lambdat
-  model$V0inv <- V0inv
-  model$A <- A
-  if(analytic) {
-    model$B <- matrix(0, length(theta), length(theta)) 
-  } else {
-    stop("Numerical Hessian not calculated in nlme::lme objects!")
-    model$B <- m@optinfo$derivs$Hessian  
-  }
-  model$C <- matrix(0, length(theta), n)
-  model$y <- y
-  model$e <- e
-  model$tye <- as.numeric(crossprod(y,e))
-  model$isREML <- m$method == "REML"
-  
-  return(model)
-  
-}
 
 getModelComponents.merMod <-
 function(m, analytic) { 

--- a/R/getcondLL.R
+++ b/R/getcondLL.R
@@ -18,11 +18,10 @@ getcondLL <- function(m) UseMethod("getcondLL")
 #' 
 getcondLL.lme <-
   function(object) {
-    stop("Fix me!")
     stopifnot(family(object)$family == "gaussian")
-    y <- object$data$y
+    y <- as.vector(getResponse(object))
     y_hat <- predict(object) # re at their predicted values
-    R <- get_R(m)
+    R <- as.matrix(get_R(object))
     sum(mvtnorm::dmvnorm(x = y, mean = y_hat, sigma = R, log = TRUE))
   }
 

--- a/R/getcondLL.R
+++ b/R/getcondLL.R
@@ -19,12 +19,12 @@ getcondLL <- function(m) UseMethod("getcondLL")
 getcondLL.lme <-
   function(object) {
     
-    stopifnot(family(m)$family == "gaussian")
-    w <- weights(m)
-    y <- m$data$y
+    stopifnot(family(object)$family == "gaussian")
+    w <- weights(object)
+    y <- object$data$y
     if(length(w) == 0) w <- rep(1,length(y))
-    y_hat <- predict(m) # re at their predicted values 
-    sum(dnorm(x = y, mean = y_hat, sd = sigma(m)/sqrt(w) , log = TRUE))
+    y_hat <- predict(object) # re at their predicted values 
+    sum(dnorm(x = y, mean = y_hat, sd = sigma(object)/sqrt(w) , log = TRUE))
 }
 
 #' @return \code{NULL}

--- a/R/getcondLL.R
+++ b/R/getcondLL.R
@@ -17,14 +17,14 @@ getcondLL <- function(m) UseMethod("getcondLL")
 #' @S3method getcondLL lme
 #' 
 getcondLL.lme <-
-function(object) {
-    
+  function(object) {
+    stop("Fix me!")
     stopifnot(family(object)$family == "gaussian")
     y <- object$data$y
-    y_hat <- predict(object) # re at their predicted values 
+    y_hat <- predict(object) # re at their predicted values
     R <- get_R(m)
-    sum(mvtnorm::dmvnorm(x = y, mean = y_hat, sigma = R,log = TRUE))
-}
+    sum(mvtnorm::dmvnorm(x = y, mean = y_hat, sigma = R, log = TRUE))
+  }
 
 #' @return \code{NULL}
 #'

--- a/R/getcondLL.R
+++ b/R/getcondLL.R
@@ -6,7 +6,33 @@
 #' @return conditional log-likelihood value
 #' @importFrom stats weights
 #' @export
-getcondLL <-
+#'
+#'
+getcondLL <- function(m) UseMethod("getcondLL")
+
+#' @return \code{NULL}
+#'
+#' @rdname getcondLL
+#' @method getcondLL lme
+#' @S3method getcondLL lme
+#' 
+getcondLL.lme <-
+  function(object) {
+    
+    stopifnot(family(m)$family == "gaussian")
+    w <- weights(m)
+    y <- m$data$y
+    if(length(w) == 0) w <- rep(1,length(y))
+    y_hat <- predict(m) # re at their predicted values 
+    sum(dnorm(x = y, mean = y_hat, sd = sigma(m)/sqrt(w) , log = TRUE))
+}
+
+#' @return \code{NULL}
+#'
+#' @rdname getcondLL
+#' @method getcondLL merMod
+#' @S3method getcondLL merMod
+getcondLL.merMod <-
 function(object) {
   # A function that calls the bias correction functions.
   #

--- a/R/getcondLL.R
+++ b/R/getcondLL.R
@@ -17,14 +17,13 @@ getcondLL <- function(m) UseMethod("getcondLL")
 #' @S3method getcondLL lme
 #' 
 getcondLL.lme <-
-  function(object) {
+function(object) {
     
     stopifnot(family(object)$family == "gaussian")
-    w <- weights(object)
     y <- object$data$y
-    if(length(w) == 0) w <- rep(1,length(y))
     y_hat <- predict(object) # re at their predicted values 
-    sum(dnorm(x = y, mean = y_hat, sd = sigma(object)/sqrt(w) , log = TRUE))
+    R <- get_R(m)
+    sum(mvtnorm::dmvnorm(x = y, mean = y_hat, sigma = R,log = TRUE))
 }
 
 #' @return \code{NULL}

--- a/R/helperfuns_lme.R
+++ b/R/helperfuns_lme.R
@@ -11,7 +11,8 @@ sort_sterms <- function(m) {
   # gamm4() respects ordering of s()-terms by, first, the s()-term with the
   # highest k comes first, in case of equal k, the s()-term are ordered as they
   # appear in the model formula with the latter terms in the model formula
-  # appearing former in the columns of Z.
+  # appearing former in the columns of Z. Disregarding the order would lead to
+  # false matrix multiplication.
 
   # only the names attribute is left after sorting
 

--- a/R/helperfuns_lme.R
+++ b/R/helperfuns_lme.R
@@ -134,7 +134,7 @@ cor_re <- function(m, cnms) {
   # splits the first entry of cnms into two parts if random itcpt and slope
   # were modelled dependently and returns the splitted version if so
 
-  if (!"Corr" %in% colnames(nlme::VarCorr(m)) & lengths(cnms[1]) == 2) {
+  if (!"Corr" %in% colnames(nlme:::VarCorr(m)) & lengths(cnms[1]) == 2) {
     # uncorrelated re have different cnms dim than correlated ones
     rev(c(split_at(cnms[[1]], 2), cnms[-1]))
   } else {
@@ -173,7 +173,7 @@ get_theta <- function(m) {
   # extracts equivalent to getME(mer,"theta") from a nlme::lme. For now, only
   # random intercept (+ slope, correlated and uncorrelated) can be handled.
 
-  re_vcov <- nlme::VarCorr(m)
+  re_vcov <- nlme:::VarCorr(m)
   sigma <- sigma(m)
 
   rnames <- rownames(re_vcov)
@@ -290,7 +290,7 @@ get_Lind <- function(m) {
 
   # extracts equivalent to getME(mer,"RX") from a nlme::lme object
 
-  no_re <- m$dims$qvec[[1]] + ("Corr" %in% colnames(nlme::VarCorr(m)))
+  no_re <- m$dims$qvec[[1]] + ("Corr" %in% colnames(nlme:::VarCorr(m)))
   n_groups <- m$dims$ngrps[[1]]
 
   if (!attr(m, "is_gamm") & no_re <= 2) {

--- a/R/helperfuns_lme.R
+++ b/R/helperfuns_lme.R
@@ -254,10 +254,10 @@ get_LambdaT <- function(m) {
 
   D <- get_D(m)
 
-  # relative covariance factor (divide by residual variance)
-  rel_vcov_fac <- D / (sigma(m)^2)
+  # relative covariance (divide by residual variance)
+  rel_vcov <- D / (sigma(m)^2)
   # may consider Cholesky() instead: Cholesky(chol_prep, LDL = FALSE, Imult=1)
-  list(LambdaT = Matrix(base::chol(rel_vcov_fac)), D = D)
+  list(LambdaT = Matrix(base::chol(rel_vcov)), D = D)
 }
 
 get_L <- function(m) {

--- a/R/helperfuns_lme.R
+++ b/R/helperfuns_lme.R
@@ -1,33 +1,6 @@
 # family function for lme objects to have a generic function
 # also working for lme models
-family.lme <- function(object, ...)
-{
-  
-  ret <- 
-    list(family = "gaussian",
-         link = "identity",
-         linkfun = function(mu) mu,
-         linkinv = function(eta) eta,
-         variance = function(mu) rep(1, length(mu)),
-         dev.resids = function(y, mu, wt) wt * ((y - mu)^2),
-         aic = function(y, n, mu, wt, dev){
-           nobs <- length(y)
-           nobs * (log(dev/nobs * 2 * pi) + 1) + 2 - sum(log(wt))
-         },
-         mu.eta = function(eta) rep.int(1, length(eta)),
-         initialize = expression({
-           n <- rep.int(1, nobs)
-           if (is.null(etastart) && is.null(start) && is.null(mustart) && 
-               ((family$link == "inverse" && any(y == 0)) || (family$link == 
-                                                              "log" && any(y <= 0)))) 
-             stop("cannot find valid starting values: please specify some")
-           mustart <- y
-         }),
-         validmu = function(mu) TRUE,
-         valideta = function(eta) TRUE)
-  class(ret) <- "family"
-  
-}
+family.lme <- function(object, ...) gaussian()
 
 count_par <- function(m, sigma.estimated = TRUE){
   

--- a/R/helperfuns_lme.R
+++ b/R/helperfuns_lme.R
@@ -28,3 +28,299 @@ family.lme <- function(object, ...)
   class(ret) <- "family"
   
 }
+
+count_par <- function(m, sigma.estimated = TRUE){
+  
+  # takes a fitted nlme::lme object and returns the number of 
+  # estimated paramters that were used to specify the residual matrix of a mixed
+  # model. Per default, the residual variance is assumed unknown and thus estimated.
+  
+  if (any("gamm" %in% class(m))) m <- m$lme
+  
+  var_str <- as.vector(m$modelStruct[["varStruct"]])
+  cor_str <- as.vector(m$modelStruct[["corStruct"]])
+  
+  length(var_str) + length(cor_str) + sigma.estimated
+}
+
+
+sort_sterms <- function(m) {
+  
+  ## takes an nlme::lme object, orders and renames the smooth parts of the
+  ## lme$data part as they are ordered in gamm4() 
+  
+  # gamm() sorts the s()-terms as they appear in the model formula.
+  # gamm4() respects ordering of s()-terms by, first, the s()-term with the highest
+  # k comes first, in case of equal k, the s()-term are ordered as they appear 
+  # in the model formula with the latter terms in the model formula appearing
+  # former in the columns of Z. 
+  
+  # only the names attribute is left after sorting
+  
+  sterm_index <- grep("^Xr",names(m$data))
+  old_names <- names(m$data)[sterm_index]
+  smooth_names <- attr(m,"smooth_names")
+  names(m$data)[sterm_index] <- paste0("s.", smooth_names)
+  knots_p_sterm <- sapply(m$data[sterm_index], ncol)
+  
+  # append old ordering to names for tracking later on
+  names(knots_p_sterm) <- paste(names(knots_p_sterm), 
+                                1:length(knots_p_sterm), sep = "..")
+  
+  # if two single smooth terms have equal k
+  uknots <- unique(knots_p_sterm)
+  how_often_unique <- sapply(uknots, function(x) sum(knots_p_sterm %in% x))
+  
+  knots_p_sterm <- sort(knots_p_sterm, decreasing = TRUE)
+  
+  if (length(uknots) == 1) knots_p_sterm <- rev(knots_p_sterm)
+  
+  if (any(how_often_unique > 1)) { # if multiple smooth terms have equal k
+    g <- uknots[how_often_unique > 1]
+    for (ind in g) {
+      index <- which(ind == knots_p_sterm)
+      names(knots_p_sterm)[index] <- rev(names(knots_p_sterm)[index])
+    }
+  }
+  n_knots <- names(knots_p_sterm)
+  new_order <- as.numeric(substr(n_knots,nchar(n_knots),nchar(n_knots)))
+  names(knots_p_sterm) <- substr(n_knots,1,nchar(n_knots)-3)
+  attr(knots_p_sterm,"old_names") <- old_names[new_order] 
+  knots_p_sterm
+}
+
+get_names <- function(x) {
+  
+  # extracts the names of the smooth parts of an mgcv::gamm object and returns
+  # them as they appear in the lme$data part of the original gamm$object. The order
+  # of the terms is crucial later on owing to the different ordering of
+  # smooth terms in gamm and gamm4. See sort_sterms for details.
+  
+  unlist(sapply(x$gam$smooth, function(x) {
+    if(is.list(x[[1]])) return(paste0(x$term, collapse = "_")) # interaction te()
+    x$term # regular s()
+  }))
+}
+
+
+get_ST <- function(m) {
+  
+  # extracts from a fitted nlme::lme object and returns a list equivalent to
+  # what is returned by getME(mer, "ST")
+  
+  theta <- get_theta(m)
+  cnms <- attr(m$modelStruct$reStruct[[1]],"Dimnames")[1] # equivalent to lme4
+  cnms <- c(cnms,attr(m,"smooth_names")) # relevant for mgcv::gamm
+  
+  cnms <- cor_re(m, cnms) # if random itcpt and slope are dependent cnms changes
+  no_re <- lengths(cnms)
+  
+  vec2mlist(theta,no_re)
+  
+}
+
+# split vector at position and return a list with the splitted elements
+split_at <- function(x, pos) unname(split(x, cumsum(seq_along(x) %in% pos)))
+
+# vec2mlist, get_clen, vec2STlist and sdiag are functions taken from the lme4
+# package
+
+vec2mlist <- function(v, n = NULL, symm = FALSE) {
+  n <- get_clen(v, n)
+  s <- split(v, rep.int(seq_along(n), n * (n + 1)/2))
+  m <- mapply(function(x, n0) {
+    m0 <- diag(nrow = n0)
+    m0[lower.tri(m0, diag = TRUE)] <- x
+    if (symm) 
+      m0[upper.tri(m0)] <- t(m0)[upper.tri(m0)]
+    m0
+  }, s, n, SIMPLIFY = FALSE)
+  m
+}
+
+get_clen <- function (v, n = NULL) {
+  if (is.null(n)) {
+    if (is.null(n <- attr(v, "clen"))) {
+      n <- (sqrt(8 * length(v) + 1) - 1)/2
+    }
+  }
+  n
+}
+
+
+vec2STlist <- function (v, n = NULL) {
+  
+  ch <- vec2mlist(v, n, FALSE)
+  
+  lapply(ch, function(L) {
+    ST <- L %*% sdiag(1/sdiag(L))
+    diag(ST) <- diag(L)
+    ST
+  })
+}
+
+sdiag <- function(x) {
+  if (length(x) == 1) 
+    matrix(x, 1, 1)
+  else diag(x)
+}
+
+cor_re <- function(m,cnms){
+  
+  # splits the first entry of cnms into two parts if random itcpt and slope
+  # were modelled dependently and returns the splitted version if so
+  
+  if (!"Corr" %in% colnames(nlme::VarCorr(m)) & lengths(cnms[1]) == 2) {
+    # uncorrelated re have different cnms dim than correlated ones  
+    rev(c(split_at(cnms[[1]],2),cnms[-1]))
+  } else {
+    cnms
+  }
+}
+
+get_theta <- function(m) {
+  
+  # extracts equivalent to getME(mer,"theta") from a nlme::lme. For now, only 
+  # random intercept (+ slope, correlated and uncorrelated) can be handled.
+  
+  re_vcov <- nlme::VarCorr(m)
+  sigma <- sigma(m)
+  
+  rnames <- rownames(re_vcov)
+  idx1 <- grep("(Intercept)",rnames)
+  idx2 <- grep("Residual",rnames)
+  var_re_itcpt <- as.numeric(re_vcov[idx1,"Variance"])
+  theta_1 <- matrix(sqrt(var_re_itcpt)/sigma)
+  
+  # more than a random intercept
+  if (idx2 - idx1 > 1) {
+    var_re_slope <- as.numeric(re_vcov[idx1 + 1,"Variance"])
+    D <- matrix(c(var_re_itcpt,0L,0L,var_re_slope), ncol = 2, byrow = TRUE)
+    theta_1 <- sqrt(diag(D))/sigma
+    if ("Corr" %in% colnames(re_vcov)) {
+      cov_re <- as.numeric(re_vcov[idx1 + 1,"Corr"])*sqrt(var_re_itcpt*var_re_slope)
+      D[2:3] <- cov_re
+      theta_1 <- base::chol(D)/sigma
+      theta_1 <- theta_1[upper.tri(theta_1, diag = TRUE)]
+    }
+  }
+  
+  if (!attr(m,"is_gamm") | length(grep("^g.",rnames)) == 0) return(theta_1)
+  
+  spline_var <- as.numeric(re_vcov[grep("^g.",rnames) + 1,1])
+  names(spline_var) <- attr(m,"smooth_names") # gamm order
+  
+  # these terms have gamm4 order
+  ordered_sterms <- names(attr(m,"ordered_smooth"))
+  ordered_sterms <- substr(ordered_sterms,3, nchar(ordered_sterms)) 
+  
+  # terms are now ordered in line with columns of getME(mer,"Z")
+  spline_var <- spline_var[ordered_sterms] # has gamm4 order
+  theta_2 <- sqrt(spline_var)/sigma
+  
+  c(theta_1,theta_2)
+  
+}
+
+count_par <- function(m, sigma.estimated = TRUE){
+  
+  # takes a fitted nlme::lme and returns the number of 
+  # estimated paramters that were used to specify the residual matrix of a mixed
+  # model. Per default, the residual variance is assumed unknown and thus estimated.
+  
+  var_str <- as.vector(m$modelStruct[["varStruct"]])
+  cor_str <- as.vector(m$modelStruct[["corStruct"]])
+  
+  length(var_str) + length(cor_str) + sigma.estimated
+}
+
+get_Z <- function(m) {
+  
+  ## extracts equivalent to getME(mer,"Z") from a nlme::lme object.
+  
+  # the spline part of RLRsim::extract.lmeDesign$Z is not convenient for usage since the
+  # ordering of the columns is not arbitrary and not in line with getME(mer,"Z")
+  
+  Z_try <- RLRsim::extract.lmeDesign(m)$Z
+  
+  no_knots <- sum(attr(m,"ordered_smooth"))
+  
+  # get (true) random effect part from Z matrix
+  random_part <- Z_try[,(no_knots + 1):ncol(Z_try)]
+  
+  # get the spline part of Z order it according to getME(mer,"Z")
+  spline_part <- m$data[attr(attr(m,"ordered_smooth"),"old_names")]
+  
+  Matrix(as.matrix(cbind(random_part,spline_part)))
+}
+
+get_LambdaT <- function(m) {
+  
+  # extracts equivalent to getME(mer,"Lambdat") from a nlme::lme object.
+  
+  res <- RLRsim::extract.lmeDesign(m)
+  D <- res$Vr*res$sigmasq # inverse order of splines and re coefs
+  
+  # find vcov coef that belong to splines and those who belong to true re
+  spline_index <- grep("^g",names(m$coefficients$random))
+  no_knots <- length(unlist(m$coefficients$random[spline_index]))
+  last_index <- nrow(D)
+  
+  # seperate parts
+  spline_vcov <- D[1:no_knots,1:no_knots]
+  random_vcov <- D[(no_knots+1):last_index,(no_knots+1):last_index]
+  
+  # build D matrix as in gamm4() by just reordering D from RLRsim
+  D <- matrix(0L,nrow = nrow(res$Vr), ncol = ncol(res$Vr)) # prepare
+  D[1:(last_index-no_knots),1:(last_index-no_knots)] <- random_vcov
+  D[(last_index -no_knots+1):last_index,(last_index -no_knots+1):last_index] <-
+    spline_vcov
+  
+  # relative covariance factor (divide by residual variance)
+  chol_prep <- D/res$sigmasq
+  # may consider Cholesky() instead: Cholesky(chol_prep, LDL = FALSE, Imult=1)
+  Matrix(base::chol(chol_prep))
+  
+}
+
+get_L <- function(m) {
+  
+  # extracts equivalent to getME(mer,"L") from a nlme::lme object
+  
+  weights <- weights(m)
+  if(length(weights) == 0) weights <- rep(1,nrow(gamm_model$lme$data))
+  sqrtW <- Diagonal(x = sqrt(as.numeric(weights)))
+  
+  Zt <- t(get_Z(m))
+  
+  ZtW <- Zt %*% sqrtW
+  Lambdat <- get_LambdaT(m)
+  as(Cholesky(tcrossprod(Lambdat %*% ZtW), LDL = FALSE, Imult=1),"sparseMatrix")
+  
+}
+
+get_RX <- function(m){
+  
+  # extracts equivalent to getME(mer,"RX") from a nlme::lme object
+  
+  chol(solve(m$varFix))*sigma(m)
+}
+
+get_Lind <- function(m) {
+  
+  # extracts equivalent to getME(mer,"RX") from a nlme::lme object
+  
+  no_re <- m$dims$qvec[[1]] + ("Corr" %in% colnames(nlme::VarCorr(m)))
+  n_groups <- m$dims$ngrps[[1]] 
+  
+  if(is.null(attr(m,"is_gamm")) & no_re <= 2) return(rep(1:no_re, each = n_groups))
+  if(is.null(attr(m,"is_gamm"))) return(rep(1:no_re, n_groups))
+  
+  knots_p_sterm <- attr(m,"ordered_smooth")
+  term <- 1:length(knots_p_sterm) + no_re
+  vemp <- vector("list", length(term))
+  for(ind in seq_len(length(term))) vemp[[ind]] <- rep(term[ind],knots_p_sterm[ind])
+  if(no_re <= 2) return(c(rep(1:no_re, each = n_groups),unlist(vemp)))
+  c(rep(1:no_re, n_groups),unlist(vemp))
+  
+}

--- a/R/helperfuns_lme.R
+++ b/R/helperfuns_lme.R
@@ -249,7 +249,7 @@ get_LambdaT <- function(m) {
   # relative covariance factor (divide by residual variance)
   chol_prep <- D / res$sigmasq
   # may consider Cholesky() instead: Cholesky(chol_prep, LDL = FALSE, Imult=1)
-  Matrix(base::chol(chol_prep))
+  list(LambdaT = Matrix(base::chol(chol_prep)), D = D)
 }
 
 get_L <- function(m) {

--- a/R/helperfuns_lme.R
+++ b/R/helperfuns_lme.R
@@ -2,52 +2,39 @@
 # also working for lme models
 family.lme <- function(object, ...) gaussian()
 
-count_par <- function(m, sigma.estimated = TRUE){
-  
-  # takes a fitted nlme::lme object and returns the number of 
-  # estimated paramters that were used to specify the residual matrix of a mixed
-  # model. Per default, the residual variance is assumed unknown and thus estimated.
-  
-  if (any("gamm" %in% class(m))) m <- m$lme
-  
-  var_str <- as.vector(m$modelStruct[["varStruct"]])
-  cor_str <- as.vector(m$modelStruct[["corStruct"]])
-  
-  length(var_str) + length(cor_str) + sigma.estimated
-}
-
-
 sort_sterms <- function(m) {
-  
+
   ## takes an nlme::lme object, orders and renames the smooth parts of the
-  ## lme$data part as they are ordered in gamm4() 
-  
+  ## lme$data part as they are ordered in gamm4()
+
   # gamm() sorts the s()-terms as they appear in the model formula.
-  # gamm4() respects ordering of s()-terms by, first, the s()-term with the highest
-  # k comes first, in case of equal k, the s()-term are ordered as they appear 
-  # in the model formula with the latter terms in the model formula appearing
-  # former in the columns of Z. 
-  
+  # gamm4() respects ordering of s()-terms by, first, the s()-term with the
+  # highest k comes first, in case of equal k, the s()-term are ordered as they
+  # appear in the model formula with the latter terms in the model formula
+  # appearing former in the columns of Z.
+
   # only the names attribute is left after sorting
-  
-  sterm_index <- grep("^Xr",names(m$data))
+
+  sterm_index <- grep("^Xr", names(m$data))
   old_names <- names(m$data)[sterm_index]
-  smooth_names <- attr(m,"smooth_names")
+  smooth_names <- attr(m, "smooth_names")
   names(m$data)[sterm_index] <- paste0("s.", smooth_names)
   knots_p_sterm <- sapply(m$data[sterm_index], ncol)
-  
+
   # append old ordering to names for tracking later on
-  names(knots_p_sterm) <- paste(names(knots_p_sterm), 
-                                1:length(knots_p_sterm), sep = "..")
-  
+  names(knots_p_sterm) <- paste(names(knots_p_sterm),
+    1:length(knots_p_sterm),
+    sep = ".."
+  )
+
   # if two single smooth terms have equal k
   uknots <- unique(knots_p_sterm)
   how_often_unique <- sapply(uknots, function(x) sum(knots_p_sterm %in% x))
-  
+
   knots_p_sterm <- sort(knots_p_sterm, decreasing = TRUE)
-  
+
   if (length(uknots) == 1) knots_p_sterm <- rev(knots_p_sterm)
-  
+
   if (any(how_often_unique > 1)) { # if multiple smooth terms have equal k
     g <- uknots[how_often_unique > 1]
     for (ind in g) {
@@ -56,40 +43,41 @@ sort_sterms <- function(m) {
     }
   }
   n_knots <- names(knots_p_sterm)
-  new_order <- as.numeric(substr(n_knots,nchar(n_knots),nchar(n_knots)))
-  names(knots_p_sterm) <- substr(n_knots,1,nchar(n_knots)-3)
-  attr(knots_p_sterm,"old_names") <- old_names[new_order] 
+  new_order <- as.numeric(substr(n_knots, nchar(n_knots), nchar(n_knots)))
+  names(knots_p_sterm) <- substr(n_knots, 1, nchar(n_knots) - 3)
+  attr(knots_p_sterm, "old_names") <- old_names[new_order]
   knots_p_sterm
 }
 
 get_names <- function(x) {
-  
+
   # extracts the names of the smooth parts of an mgcv::gamm object and returns
-  # them as they appear in the lme$data part of the original gamm$object. The order
-  # of the terms is crucial later on owing to the different ordering of
+  # them as they appear in the lme$data part of the original gamm$object. The
+  # order of the terms is crucial later on owing to the different ordering of
   # smooth terms in gamm and gamm4. See sort_sterms for details.
-  
+
   unlist(sapply(x$gam$smooth, function(x) {
-    if(is.list(x[[1]])) return(paste0(x$term, collapse = "_")) # interaction te()
+    if (is.list(x[[1]])) {
+      return(paste0(x$term, collapse = "_"))
+    } # interaction te()
     x$term # regular s()
   }))
 }
 
 
 get_ST <- function(m) {
-  
+
   # extracts from a fitted nlme::lme object and returns a list equivalent to
   # what is returned by getME(mer, "ST")
-  
+
   theta <- get_theta(m)
-  cnms <- attr(m$modelStruct$reStruct[[1]],"Dimnames")[1] # equivalent to lme4
-  cnms <- c(cnms,attr(m,"smooth_names")) # relevant for mgcv::gamm
-  
+  cnms <- attr(m$modelStruct$reStruct[[1]], "Dimnames")[1] # equivalent to lme4
+  cnms <- c(cnms, attr(m, "smooth_names")) # relevant for mgcv::gamm
+
   cnms <- cor_re(m, cnms) # if random itcpt and slope are dependent cnms changes
   no_re <- lengths(cnms)
-  
-  vec2mlist(theta,no_re)
-  
+
+  vec2mlist(theta, no_re)
 }
 
 # split vector at position and return a list with the splitted elements
@@ -100,227 +88,239 @@ split_at <- function(x, pos) unname(split(x, cumsum(seq_along(x) %in% pos)))
 
 vec2mlist <- function(v, n = NULL, symm = FALSE) {
   n <- get_clen(v, n)
-  s <- split(v, rep.int(seq_along(n), n * (n + 1)/2))
+  s <- split(v, rep.int(seq_along(n), n * (n + 1) / 2))
   m <- mapply(function(x, n0) {
     m0 <- diag(nrow = n0)
     m0[lower.tri(m0, diag = TRUE)] <- x
-    if (symm) 
+    if (symm) {
       m0[upper.tri(m0)] <- t(m0)[upper.tri(m0)]
+    }
     m0
   }, s, n, SIMPLIFY = FALSE)
   m
 }
 
-get_clen <- function (v, n = NULL) {
+get_clen <- function(v, n = NULL) {
   if (is.null(n)) {
     if (is.null(n <- attr(v, "clen"))) {
-      n <- (sqrt(8 * length(v) + 1) - 1)/2
+      n <- (sqrt(8 * length(v) + 1) - 1) / 2
     }
   }
   n
 }
 
 
-vec2STlist <- function (v, n = NULL) {
-  
+vec2STlist <- function(v, n = NULL) {
   ch <- vec2mlist(v, n, FALSE)
-  
+
   lapply(ch, function(L) {
-    ST <- L %*% sdiag(1/sdiag(L))
+    ST <- L %*% sdiag(1 / sdiag(L))
     diag(ST) <- diag(L)
     ST
   })
 }
 
 sdiag <- function(x) {
-  if (length(x) == 1) 
+  if (length(x) == 1) {
     matrix(x, 1, 1)
-  else diag(x)
+  } else {
+    diag(x)
+  }
 }
 
-cor_re <- function(m,cnms){
-  
+cor_re <- function(m, cnms) {
+
   # splits the first entry of cnms into two parts if random itcpt and slope
   # were modelled dependently and returns the splitted version if so
-  
+
   if (!"Corr" %in% colnames(nlme::VarCorr(m)) & lengths(cnms[1]) == 2) {
-    # uncorrelated re have different cnms dim than correlated ones  
-    rev(c(split_at(cnms[[1]],2),cnms[-1]))
+    # uncorrelated re have different cnms dim than correlated ones
+    rev(c(split_at(cnms[[1]], 2), cnms[-1]))
   } else {
     cnms
   }
 }
 
 get_theta <- function(m) {
-  
-  # extracts equivalent to getME(mer,"theta") from a nlme::lme. For now, only 
+
+  # extracts equivalent to getME(mer,"theta") from a nlme::lme. For now, only
   # random intercept (+ slope, correlated and uncorrelated) can be handled.
-  
+
   re_vcov <- nlme::VarCorr(m)
   sigma <- sigma(m)
-  
+
   rnames <- rownames(re_vcov)
-  idx1 <- grep("(Intercept)",rnames)
-  idx2 <- grep("Residual",rnames)
-  var_re_itcpt <- as.numeric(re_vcov[idx1,"Variance"])
-  theta_1 <- matrix(sqrt(var_re_itcpt)/sigma)
-  
+  idx1 <- grep("(Intercept)", rnames)
+  idx2 <- grep("Residual", rnames)
+  var_re_itcpt <- as.numeric(re_vcov[idx1, "Variance"])
+  theta_1 <- matrix(sqrt(var_re_itcpt) / sigma)
+
   # more than a random intercept
   if (idx2 - idx1 > 1) {
-    var_re_slope <- as.numeric(re_vcov[idx1 + 1,"Variance"])
-    D <- matrix(c(var_re_itcpt,0L,0L,var_re_slope), ncol = 2, byrow = TRUE)
-    theta_1 <- sqrt(diag(D))/sigma
+    var_re_slope <- as.numeric(re_vcov[idx1 + 1, "Variance"])
+    D <- matrix(c(var_re_itcpt, 0L, 0L, var_re_slope), ncol = 2, byrow = TRUE)
+    theta_1 <- sqrt(diag(D)) / sigma
     if ("Corr" %in% colnames(re_vcov)) {
-      cov_re <- as.numeric(re_vcov[idx1 + 1,"Corr"])*sqrt(var_re_itcpt*var_re_slope)
+      cov_re <- as.numeric(re_vcov[idx1 + 1, "Corr"]) * sqrt(var_re_itcpt *
+        var_re_slope)
       D[2:3] <- cov_re
-      theta_1 <- base::chol(D)/sigma
+      theta_1 <- base::chol(D) / sigma
       theta_1 <- theta_1[upper.tri(theta_1, diag = TRUE)]
     }
   }
-  
-  if (!attr(m,"is_gamm") | length(grep("^g.",rnames)) == 0) return(theta_1)
-  
-  spline_var <- as.numeric(re_vcov[grep("^g.",rnames) + 1,1])
-  names(spline_var) <- attr(m,"smooth_names") # gamm order
-  
+
+  if (!attr(m, "is_gamm") | length(grep("^g.", rnames)) == 0) {
+    return(theta_1)
+  }
+
+  spline_var <- as.numeric(re_vcov[grep("^g.", rnames) + 1, 1])
+  names(spline_var) <- attr(m, "smooth_names") # gamm order
+
   # these terms have gamm4 order
-  ordered_sterms <- names(attr(m,"ordered_smooth"))
-  ordered_sterms <- substr(ordered_sterms,3, nchar(ordered_sterms)) 
-  
+  ordered_sterms <- names(attr(m, "ordered_smooth"))
+  ordered_sterms <- substr(ordered_sterms, 3, nchar(ordered_sterms))
+
   # terms are now ordered in line with columns of getME(mer,"Z")
   spline_var <- spline_var[ordered_sterms] # has gamm4 order
-  theta_2 <- sqrt(spline_var)/sigma
-  
-  c(theta_1,theta_2)
-  
+  theta_2 <- sqrt(spline_var) / sigma
+
+  c(theta_1, theta_2)
 }
 
-count_par <- function(m, sigma.estimated = TRUE){
-  
-  # takes a fitted nlme::lme and returns the number of 
+count_par <- function(m, sigma.estimated = TRUE) {
+
+  # takes a fitted nlme::lme and returns the number of
   # estimated paramters that were used to specify the residual matrix of a mixed
-  # model. Per default, the residual variance is assumed unknown and thus estimated.
-  
+  # model. Per default, the residual variance is assumed unknown and thus
+  # estimated.
+
   var_str <- as.vector(m$modelStruct[["varStruct"]])
   cor_str <- as.vector(m$modelStruct[["corStruct"]])
-  
+
   length(var_str) + length(cor_str) + sigma.estimated
 }
 
 get_Z <- function(m) {
-  
+
   ## extracts equivalent to getME(mer,"Z") from a nlme::lme object.
-  
-  # the spline part of RLRsim::extract.lmeDesign$Z is not convenient for usage since the
-  # ordering of the columns is not arbitrary and not in line with getME(mer,"Z")
-  
+
+  # the spline part of RLRsim::extract.lmeDesign$Z is not convenient for usage
+  # since the ordering of the columns is not arbitrary and not in line with
+  # getME(mer,"Z")
+
   Z_try <- RLRsim::extract.lmeDesign(m)$Z
-  
-  no_knots <- sum(attr(m,"ordered_smooth"))
-  
+
+  no_knots <- sum(attr(m, "ordered_smooth"))
+
   # get (true) random effect part from Z matrix
-  random_part <- Z_try[,(no_knots + 1):ncol(Z_try)]
-  
+  random_part <- Z_try[, (no_knots + 1):ncol(Z_try)]
+
   # get the spline part of Z order it according to getME(mer,"Z")
-  spline_part <- m$data[attr(attr(m,"ordered_smooth"),"old_names")]
-  
-  Matrix(as.matrix(cbind(random_part,spline_part)))
+  spline_part <- m$data[attr(attr(m, "ordered_smooth"), "old_names")]
+
+  Matrix(as.matrix(cbind(random_part, spline_part)))
 }
 
 get_LambdaT <- function(m) {
-  
+
   # extracts equivalent to getME(mer,"Lambdat") from a nlme::lme object.
-  
+
   res <- RLRsim::extract.lmeDesign(m)
-  D <- res$Vr*res$sigmasq # inverse order of splines and re coefs
-  
+  D <- res$Vr * res$sigmasq # inverse order of splines and re coefs
+
   # find vcov coef that belong to splines and those who belong to true re
-  spline_index <- grep("^g",names(m$coefficients$random))
+  spline_index <- grep("^g", names(m$coefficients$random))
   no_knots <- length(unlist(m$coefficients$random[spline_index]))
   last_index <- nrow(D)
-  
+
   if (length(spline_index) != 0) {
     # seperate parts
-    spline_vcov <- D[1:no_knots,1:no_knots]
-    random_vcov <- D[(no_knots+1):last_index,(no_knots+1):last_index]
-  
+    spline_vcov <- D[1:no_knots, 1:no_knots]
+    random_vcov <- D[(no_knots + 1):last_index, (no_knots + 1):last_index]
+
     # build D matrix as in gamm4() by just reordering D from RLRsim
-    D <- matrix(0L,nrow = nrow(res$Vr), ncol = ncol(res$Vr)) # prepare
-    D[1:(last_index-no_knots),1:(last_index-no_knots)] <- random_vcov
-    D[(last_index -no_knots+1):last_index,(last_index -no_knots+1):last_index] <-
-      spline_vcov
+    D <- matrix(0L, nrow = nrow(res$Vr), ncol = ncol(res$Vr)) # prepare
+    D[1:(last_index - no_knots), 1:(last_index - no_knots)] <- random_vcov
+    D[(last_index - no_knots + 1):last_index, (last_index - no_knots + 1):
+    last_index] <- spline_vcov
   }
-  
+
   # relative covariance factor (divide by residual variance)
-  chol_prep <- D/res$sigmasq
+  chol_prep <- D / res$sigmasq
   # may consider Cholesky() instead: Cholesky(chol_prep, LDL = FALSE, Imult=1)
   Matrix(base::chol(chol_prep))
-  
 }
 
 get_L <- function(m) {
-  
+
   # extracts equivalent to getME(mer,"L") from a nlme::lme object
   stop("Fix me!")
-  R <- bdiag(getVarCov(m,type = "c", individuals = 1:m$dims$ngrps[[1]]))
-  
-  #weights <- weights(m)
-  #if(length(weights) == 0) weights <- rep(1,nrow(m$data))
-  #sqrtW <- Diagonal(x = sqrt(as.numeric(weights)))
-  
+  R <- bdiag(getVarCov(m, type = "c", individuals = 1:m$dims$ngrps[[1]]))
+
+  # weights <- weights(m)
+  # if(length(weights) == 0) weights <- rep(1,nrow(m$data))
+  # sqrtW <- Diagonal(x = sqrt(as.numeric(weights)))
+
   Zt <- t(get_Z(m))
-  
-  ZtW <- Zt %*% R #sqrtW
+
+  ZtW <- Zt %*% R # sqrtW
   Lambdat <- get_LambdaT(m)
-  as(Cholesky(tcrossprod(Lambdat %*% ZtW), LDL = FALSE, Imult = 1),"sparseMatrix")
-  
+  as(
+    Cholesky(tcrossprod(Lambdat %*% ZtW), LDL = FALSE, Imult = 1),
+    "sparseMatrix"
+  )
 }
 
-get_RX <- function(m){
-  
+get_RX <- function(m) {
+
   # extracts equivalent to getME(mer,"RX") from a nlme::lme object
-  
-  chol(solve(m$varFix))*sigma(m)
+
+  chol(solve(m$varFix)) * sigma(m)
 }
 
 get_Lind <- function(m) {
-  
+
   # extracts equivalent to getME(mer,"RX") from a nlme::lme object
 
   no_re <- m$dims$qvec[[1]] + ("Corr" %in% colnames(nlme::VarCorr(m)))
-  n_groups <- m$dims$ngrps[[1]] 
-  
-  if(is.null(attr(m,"is_gamm")) & no_re <= 2) return(rep(1:no_re, each = n_groups))
-  if(is.null(attr(m,"is_gamm"))) return(rep(1:no_re, n_groups))
-  
-  knots_p_sterm <- attr(m,"ordered_smooth")
+  n_groups <- m$dims$ngrps[[1]]
+
+  if (is.null(attr(m, "is_gamm")) & no_re <= 2) {
+    return(rep(1:no_re, each = n_groups))
+  }
+  if (is.null(attr(m, "is_gamm"))) {
+    return(rep(1:no_re, n_groups))
+  }
+
+  knots_p_sterm <- attr(m, "ordered_smooth")
   term <- 1:length(knots_p_sterm) + no_re
   vemp <- vector("list", length(term))
-  for(ind in seq_len(length(term))) vemp[[ind]] <- rep(term[ind],knots_p_sterm[ind])
-  if(no_re <= 2) return(c(rep(1:no_re, each = n_groups),unlist(vemp)))
-  c(rep(1:no_re, n_groups),unlist(vemp))
-  
+  for (ind in seq_len(length(term))) {
+    vemp[[ind]] <- rep(
+      term[ind],
+      knots_p_sterm[ind]
+    )
+  }
+  if (no_re <= 2) {
+    return(c(rep(1:no_re, each = n_groups), unlist(vemp)))
+  }
+  c(rep(1:no_re, n_groups), unlist(vemp))
 }
 
 get_R <- function(m) {
-  
-  # returns the cond. VCov of a mixed model fitted with nlme::lme as a block - 
-  # diag matrix. In the case of homoscedastic error variance the main diagonal 
+
+  # returns the cond. VCov of a mixed model fitted with nlme::lme as a block -
+  # diag matrix. In the case of homoscedastic error variance the main diagonal
   # contains sigma(m)^2. For now, a nested mixed model can not be handled.
-  
-  # some gamms contain a pesudo nesting structure (s-terms) which needs 
+
+  # some gamms contain a pesudo nesting structure (s-terms) which needs
   # to be exlcuded
-  nlev_col <- sapply(m$groups,nlevels)
-  if (ncol(m$groups) > 1) m$groups <- m$groups[,nlev_col > 1,drop = FALSE]
-  
+  nlev_col <- sapply(m$groups, nlevels)
+  if (ncol(m$groups) > 1) m$groups <- m$groups[, nlev_col > 1, drop = FALSE]
+
   n <- m$dims$ngrps[1]
-  vcov_list <- sapply(1:n, function(x) nlme::getVarCov(m, 
-                                                       type = "conditional", x))
+  vcov_list <- sapply(1:n, function(x) nlme::getVarCov(m,
+      type = "conditional", x
+    ))
   Matrix::bdiag(vcov_list)
 }
-
-
-
-
-
-


### PR DESCRIPTION
cAIC4 ought now be able to handle objects from nlme::lme and mgcv::gamm. Since one is able to specify the weights and the correlation argument in nlme::lme objects, the corresponding cAIC can now be calculated as well. In addition, since lme4 can handle prespecified weights, the existing cAIC for lme4:::lmer objects can now incorporate weights as well.